### PR TITLE
Some improvements

### DIFF
--- a/src/Middleware/UserOnlineMiddleware.php
+++ b/src/Middleware/UserOnlineMiddleware.php
@@ -20,7 +20,7 @@ class UserOnlineMiddleware
     {
         $response = $next($request);
         if (Auth::check()) {
-            Cache::store('file')->put('userIsOnline-'.Auth::user()->id, 'true', now()->addMinutes(config('komichoUserOnline.time_allowed')));
+            Cache::put('userIsOnline-'.Auth::user()->id, 'true', now()->addMinutes(config('komichoUserOnline.time_allowed')));
         }
         return $response;
     }

--- a/src/Traits/UserOnline.php
+++ b/src/Traits/UserOnline.php
@@ -9,10 +9,6 @@ trait UserOnline
 {
     public function isOnline()
     {
-        if (Auth::id() == $this->id) {
-            return false;
-        }
-
         if (Cache::has('userIsOnline-'.$this->id)) {
             return true;
         }


### PR DESCRIPTION
**Return correct online status for the current user**
Albeit returning the online status to the current user is somewhat pointless, returning false (offline) is not correct.

**Use default cache driver**
Instead of explicitly using file, use cache driver specified in config/cache.php respectively .env (which is a file by default anyway).